### PR TITLE
SYNCT-276: Extend the configuration to give fine grained control

### DIFF
--- a/api/src/main/java/org/openmrs/module/sync2/SyncConstants.java
+++ b/api/src/main/java/org/openmrs/module/sync2/SyncConstants.java
@@ -40,6 +40,8 @@ public class SyncConstants {
 
     public static final String AUDIT_MESSAGE_VOIDED_FIELD_NAME = "voided";
 
+    public static final String ALL_OPERATIONS = "ALL";
+
     public static final String PULL_OPERATION = "PULL";
 
     public static final String PUSH_OPERATION = "PUSH";
@@ -47,6 +49,8 @@ public class SyncConstants {
     public static final String FHIR_CLIENT = "fhir";
 
     public static final String REST_CLIENT = "rest";
+
+    public static final String DEFAULT_SYNC_2_CLIENT = REST_CLIENT;
 
     public static final String RECENT_FEED = "recent";
 

--- a/api/src/main/java/org/openmrs/module/sync2/SyncConstants.java
+++ b/api/src/main/java/org/openmrs/module/sync2/SyncConstants.java
@@ -40,7 +40,6 @@ public class SyncConstants {
 
     public static final String AUDIT_MESSAGE_VOIDED_FIELD_NAME = "voided";
 
-
     public static final String ALL_OPERATIONS = "ALL";
 
     public static final String AUDIT_MESSAGE_MERGE_CONFLICT_UUID_NAME = "mergeConflictUuid";

--- a/api/src/main/java/org/openmrs/module/sync2/api/model/configuration/ClassConfiguration.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/model/configuration/ClassConfiguration.java
@@ -1,13 +1,21 @@
 package org.openmrs.module.sync2.api.model.configuration;
 
+import java.io.Serializable;
 import java.util.Objects;
 
-public class ClassConfiguration {
+public class ClassConfiguration implements Serializable {
+
+    private static final long serialVersionUID = -6874334396673035705L;
 
     private String classTitle;
+
     private String category;
+
     private String openMrsClass;
+
     private boolean enabled;
+
+    private String preferredClient;
 
     public ClassConfiguration() { }
 
@@ -16,6 +24,15 @@ public class ClassConfiguration {
         this.category = category;
         this.openMrsClass = openMrsClass;
         this.enabled = enabled;
+    }
+
+    public ClassConfiguration(String classTitle, String category, String openMrsClass, boolean enabled,
+            String preferredClient) {
+        this.classTitle = classTitle;
+        this.category = category;
+        this.openMrsClass = openMrsClass;
+        this.enabled = enabled;
+        this.preferredClient = preferredClient;
     }
 
     public String getClassTitle() {
@@ -50,6 +67,14 @@ public class ClassConfiguration {
         this.enabled = enabled;
     }
 
+    public String getPreferredClient() {
+        return preferredClient;
+    }
+
+    public void setPreferredClient(String preferredClient) {
+        this.preferredClient = preferredClient;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -62,11 +87,12 @@ public class ClassConfiguration {
         return enabled == that.enabled
                 && Objects.equals(classTitle, that.classTitle)
                 && Objects.equals(category, that.category)
-                && Objects.equals(openMrsClass, that.openMrsClass);
+                && Objects.equals(openMrsClass, that.openMrsClass)
+                && Objects.equals(preferredClient, that.preferredClient);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(classTitle, category, openMrsClass, enabled);
+        return Objects.hash(classTitle, category, openMrsClass, enabled, preferredClient);
     }
 }

--- a/api/src/main/java/org/openmrs/module/sync2/api/model/configuration/ClientConfiguration.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/model/configuration/ClientConfiguration.java
@@ -9,10 +9,16 @@ public class ClientConfiguration implements Serializable {
 
 	private String hostAddress;
 
+	private String login;
+
+	private String password;
+
 	public ClientConfiguration() { }
 
-	public ClientConfiguration(String hostAddress) {
+	public ClientConfiguration(String hostAddress, String login, String password) {
 		this.hostAddress = hostAddress;
+		this.login = login;
+		this.password = password;
 	}
 
 	public String getHostAddress() {
@@ -23,6 +29,22 @@ public class ClientConfiguration implements Serializable {
 		this.hostAddress = hostAddress;
 	}
 
+	public String getLogin() {
+		return login;
+	}
+
+	public void setLogin(String login) {
+		this.login = login;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o)
@@ -30,11 +52,13 @@ public class ClientConfiguration implements Serializable {
 		if (o == null || getClass() != o.getClass())
 			return false;
 		ClientConfiguration that = (ClientConfiguration) o;
-		return Objects.equals(hostAddress, that.hostAddress);
+		return Objects.equals(hostAddress, that.hostAddress) &&
+				Objects.equals(login, that.login) &&
+				Objects.equals(password, that.password);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(hostAddress);
+		return Objects.hash(hostAddress, login, password);
 	}
 }

--- a/api/src/main/java/org/openmrs/module/sync2/api/model/configuration/ClientConfiguration.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/model/configuration/ClientConfiguration.java
@@ -1,0 +1,40 @@
+package org.openmrs.module.sync2.api.model.configuration;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class ClientConfiguration implements Serializable {
+
+	private static final long serialVersionUID = -2597794749882756894L;
+
+	private String hostAddress;
+
+	public ClientConfiguration() { }
+
+	public ClientConfiguration(String hostAddress) {
+		this.hostAddress = hostAddress;
+	}
+
+	public String getHostAddress() {
+		return hostAddress;
+	}
+
+	public void setHostAddress(String hostAddress) {
+		this.hostAddress = hostAddress;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		ClientConfiguration that = (ClientConfiguration) o;
+		return Objects.equals(hostAddress, that.hostAddress);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(hostAddress);
+	}
+}

--- a/api/src/main/java/org/openmrs/module/sync2/api/model/configuration/GeneralConfiguration.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/model/configuration/GeneralConfiguration.java
@@ -1,8 +1,11 @@
 package org.openmrs.module.sync2.api.model.configuration;
 
+import java.io.Serializable;
 import java.util.Objects;
 
-public class GeneralConfiguration {
+public class GeneralConfiguration implements Serializable {
+
+    private static final long serialVersionUID = -2762773054306474129L;
 
     private String parentFeedLocation;
     private String localFeedLocation;

--- a/api/src/main/java/org/openmrs/module/sync2/api/model/configuration/GeneralConfiguration.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/model/configuration/GeneralConfiguration.java
@@ -1,6 +1,7 @@
 package org.openmrs.module.sync2.api.model.configuration;
 
 import java.io.Serializable;
+import java.util.LinkedHashMap;
 import java.util.Objects;
 
 public class GeneralConfiguration implements Serializable {
@@ -17,15 +18,21 @@ public class GeneralConfiguration implements Serializable {
 
     private boolean persistFailureAudit;
 
-    public GeneralConfiguration() { }
+    private LinkedHashMap<String, ClientConfiguration> clients;
+
+    public GeneralConfiguration() {
+        clients = new LinkedHashMap<>();
+    }
 
     public GeneralConfiguration(String parentFeedLocation, String localFeedLocation, String localInstanceId,
-                                boolean persistSuccessAudit, boolean persistFailureAudit) {
+                                boolean persistSuccessAudit, boolean persistFailureAudit,
+            LinkedHashMap<String, ClientConfiguration> clients) {
         this.parentFeedLocation = parentFeedLocation;
         this.localFeedLocation = localFeedLocation;
         this.localInstanceId = localInstanceId;
         this.persistSuccessAudit = persistSuccessAudit;
         this.persistFailureAudit = persistFailureAudit;
+        this.clients = clients;
     }
 
     public String getParentFeedLocation() {
@@ -67,7 +74,15 @@ public class GeneralConfiguration implements Serializable {
     public void setLocalInstanceId(String localInstanceId) {
         this.localInstanceId = localInstanceId;
     }
-    
+
+    public LinkedHashMap<String, ClientConfiguration> getClients() {
+        return clients;
+    }
+
+    public void setClients(LinkedHashMap<String, ClientConfiguration> clients) {
+        this.clients = clients;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -81,12 +96,13 @@ public class GeneralConfiguration implements Serializable {
                 && Objects.equals(localFeedLocation, that.localFeedLocation)
                 && Objects.equals(localInstanceId, that.localInstanceId)
                 && Objects.equals(persistSuccessAudit, that.persistSuccessAudit)
-                && Objects.equals(persistFailureAudit, that.persistFailureAudit);
+                && Objects.equals(persistFailureAudit, that.persistFailureAudit)
+                && Objects.deepEquals(clients, that.clients);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(parentFeedLocation, localFeedLocation, localInstanceId,
-                persistSuccessAudit, persistFailureAudit);
+                persistSuccessAudit, persistFailureAudit, clients);
     }
 }

--- a/api/src/main/java/org/openmrs/module/sync2/api/model/configuration/GeneralConfiguration.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/model/configuration/GeneralConfiguration.java
@@ -8,9 +8,13 @@ public class GeneralConfiguration implements Serializable {
     private static final long serialVersionUID = -2762773054306474129L;
 
     private String parentFeedLocation;
+
     private String localFeedLocation;
+
     private String localInstanceId;
+
     private boolean persistSuccessAudit;
+
     private boolean persistFailureAudit;
 
     public GeneralConfiguration() { }

--- a/api/src/main/java/org/openmrs/module/sync2/api/model/configuration/SyncConfiguration.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/model/configuration/SyncConfiguration.java
@@ -1,8 +1,11 @@
 package org.openmrs.module.sync2.api.model.configuration;
 
+import java.io.Serializable;
 import java.util.Objects;
 
-public class SyncConfiguration {
+public class SyncConfiguration implements Serializable {
+
+    private static final long serialVersionUID = 6912987641002329930L;
 
     private GeneralConfiguration general;
     private SyncMethodConfiguration push;

--- a/api/src/main/java/org/openmrs/module/sync2/api/model/configuration/SyncConfiguration.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/model/configuration/SyncConfiguration.java
@@ -8,8 +8,11 @@ public class SyncConfiguration implements Serializable {
     private static final long serialVersionUID = 6912987641002329930L;
 
     private GeneralConfiguration general;
+
     private SyncMethodConfiguration push;
+
     private SyncMethodConfiguration pull;
+
     private WhitelistConfiguration whitelist;
 
     public SyncConfiguration() {

--- a/api/src/main/java/org/openmrs/module/sync2/api/model/configuration/SyncMethodConfiguration.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/model/configuration/SyncMethodConfiguration.java
@@ -1,10 +1,13 @@
 package org.openmrs.module.sync2.api.model.configuration;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-public class SyncMethodConfiguration {
+public class SyncMethodConfiguration implements Serializable {
+
+    private static final long serialVersionUID = -6931575656903938518L;
 
     private boolean enabled;
     private Integer schedule;

--- a/api/src/main/java/org/openmrs/module/sync2/api/model/configuration/SyncMethodConfiguration.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/model/configuration/SyncMethodConfiguration.java
@@ -10,7 +10,9 @@ public class SyncMethodConfiguration implements Serializable {
     private static final long serialVersionUID = -6931575656903938518L;
 
     private boolean enabled;
+
     private Integer schedule;
+
     private List<ClassConfiguration> classes;
 
     public SyncMethodConfiguration() {

--- a/api/src/main/java/org/openmrs/module/sync2/api/model/configuration/WhitelistConfiguration.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/model/configuration/WhitelistConfiguration.java
@@ -1,10 +1,13 @@
 package org.openmrs.module.sync2.api.model.configuration;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-public class WhitelistConfiguration {
+public class WhitelistConfiguration implements Serializable {
+
+    private static final long serialVersionUID = 3878263730073981879L;
 
     private boolean enabled;
     private List<String> instanceIds;

--- a/api/src/main/java/org/openmrs/module/sync2/api/model/configuration/WhitelistConfiguration.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/model/configuration/WhitelistConfiguration.java
@@ -10,6 +10,7 @@ public class WhitelistConfiguration implements Serializable {
     private static final long serialVersionUID = 3878263730073981879L;
 
     private boolean enabled;
+
     private List<String> instanceIds;
 
     public WhitelistConfiguration() {

--- a/api/src/main/java/org/openmrs/module/sync2/api/model/enums/Operation.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/model/enums/Operation.java
@@ -1,6 +1,0 @@
-package org.openmrs.module.sync2.api.model.enums;
-
-public enum Operation {
-    ALL, PUSH, PULL;
-
-}

--- a/api/src/main/java/org/openmrs/module/sync2/api/model/enums/SyncOperation.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/model/enums/SyncOperation.java
@@ -1,0 +1,28 @@
+package org.openmrs.module.sync2.api.model.enums;
+
+import org.openmrs.module.sync2.SyncConstants;
+
+public enum SyncOperation {
+    ALL(SyncConstants.ALL_OPERATIONS), PUSH(SyncConstants.PUSH_OPERATION), PULL(SyncConstants.PULL_OPERATION);
+
+    private String value;
+
+    SyncOperation(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static SyncOperation getByValue(String value) {
+        SyncOperation result = SyncOperation.ALL;
+        for (SyncOperation operation : SyncOperation.values()) {
+            if (operation.getValue().equalsIgnoreCase(value)) {
+                result = operation;
+                break;
+            }
+        }
+        return result;
+    }
+}

--- a/api/src/main/java/org/openmrs/module/sync2/api/service/SyncConfigurationService.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/service/SyncConfigurationService.java
@@ -1,6 +1,8 @@
 package org.openmrs.module.sync2.api.service;
 
+import org.openmrs.module.sync2.api.model.configuration.ClassConfiguration;
 import org.openmrs.module.sync2.api.model.configuration.SyncConfiguration;
+import org.openmrs.module.sync2.api.model.enums.SyncOperation;
 import org.openmrs.module.sync2.api.validator.Errors;
 
 public interface SyncConfigurationService {
@@ -10,6 +12,8 @@ public interface SyncConfigurationService {
     void saveConfiguration(String jsonConfiguration);
 
     SyncConfiguration getSyncConfiguration();
+
+    ClassConfiguration getClassConfiguration(String category, SyncOperation operation);
 
     Errors validateConfiguration();
 }

--- a/api/src/main/java/org/openmrs/module/sync2/api/service/impl/AbstractSynchronizationService.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/service/impl/AbstractSynchronizationService.java
@@ -14,6 +14,7 @@ import org.openmrs.module.sync2.api.mapper.MergeConflictMapper;
 import org.openmrs.module.sync2.api.model.SyncObject;
 import org.openmrs.module.sync2.api.model.audit.AuditMessage;
 import org.openmrs.module.sync2.api.model.enums.OpenMRSSyncInstance;
+import org.openmrs.module.sync2.api.model.enums.SyncOperation;
 import org.openmrs.module.sync2.api.service.MergeConflictService;
 import org.openmrs.module.sync2.api.sync.SyncClient;
 import org.openmrs.module.sync2.api.utils.SyncConfigurationUtils;
@@ -64,7 +65,7 @@ public abstract class AbstractSynchronizationService {
     protected abstract AuditMessage synchronizeObject(String category, Map<String, String> resourceLinks,
             String action, String clientName, String uuid);
 
-    protected abstract String getOperation();
+    protected abstract SyncOperation getOperation();
 
     protected abstract String getBaseResourceUrl(Map<String, String> resourceLinks, String clientName);
 
@@ -98,7 +99,7 @@ public abstract class AbstractSynchronizationService {
         FeedConfiguration configuration = feedConfigurationService.getFeedConfigurationByCategory(category);
 
         Map<String, String> resourceLinks = configuration.getLinkTemplates();
-        String clientName = SyncUtils.selectAppropriateClientName(resourceLinks);
+        String clientName = SyncUtils.selectAppropriateClientName(resourceLinks, category, getOperation());
         Map<String, String> mappedResourceLinks = includeUuidInResourceLinks(resourceLinks, uuid);
 
         String restUrl = mappedResourceLinks.get(REST_CLIENT);
@@ -173,7 +174,7 @@ public abstract class AbstractSynchronizationService {
 
     private AuditMessage prepareAuditMessage(String category, String clientName,
             Map<String, String> resourceLinks, String action) {
-        AuditMessage auditMessage = prepareBaseAuditMessage(getOperation());
+        AuditMessage auditMessage = prepareBaseAuditMessage(getOperation().getValue());
         auditMessage.setResourceName(category);
         auditMessage.setUsedResourceUrl(getBaseResourceUrl(resourceLinks, clientName));
         auditMessage.setLinkType(clientName);

--- a/api/src/main/java/org/openmrs/module/sync2/api/service/impl/AbstractSynchronizationService.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/service/impl/AbstractSynchronizationService.java
@@ -8,6 +8,7 @@ import org.openmrs.module.atomfeed.api.service.FeedConfigurationService;
 import org.openmrs.module.fhir.api.merge.MergeConflict;
 import org.openmrs.module.fhir.api.merge.MergeResult;
 import org.openmrs.module.fhir.api.merge.MergeSuccess;
+import org.openmrs.module.sync2.SyncConstants;
 import org.openmrs.module.sync2.api.conflict.ConflictDetection;
 import org.openmrs.module.sync2.api.exceptions.MergeConflictException;
 import org.openmrs.module.sync2.api.mapper.MergeConflictMapper;
@@ -174,7 +175,7 @@ public abstract class AbstractSynchronizationService {
 
     private AuditMessage prepareAuditMessage(String category, String clientName,
             Map<String, String> resourceLinks, String action) {
-        AuditMessage auditMessage = prepareBaseAuditMessage(getOperation().getValue());
+        AuditMessage auditMessage = prepareBaseAuditMessage(getOperation().getValue(), clientName);
         auditMessage.setResourceName(category);
         auditMessage.setUsedResourceUrl(getBaseResourceUrl(resourceLinks, clientName));
         auditMessage.setLinkType(clientName);
@@ -193,10 +194,10 @@ public abstract class AbstractSynchronizationService {
 
     private List<String> determineActions(String category, String restUrl) {
         String localPullUrl = SyncUtils.getFullUrl(SyncUtils.getLocalBaseUrl(), restUrl);
-        String parentPullUrl = SyncUtils.getFullUrl(SyncUtils.getParentBaseUrl(), restUrl);
+        String parentPullUrl = SyncUtils.getFullUrl(SyncUtils.getParentBaseUrl(SyncConstants.REST_CLIENT), restUrl);
 
-        Object localObj = syncClient.pullData(category, REST_CLIENT, localPullUrl, CHILD);
-        Object parentObj = syncClient.pullData(category, REST_CLIENT, parentPullUrl, PARENT);
+        Object localObj = syncClient.pullData(category, SyncConstants.REST_CLIENT, localPullUrl, CHILD);
+        Object parentObj = syncClient.pullData(category, SyncConstants.REST_CLIENT, parentPullUrl, PARENT);
 
         return determineActionsBasingOnSyncType(localObj, parentObj);
     }

--- a/api/src/main/java/org/openmrs/module/sync2/api/service/impl/SyncConfigurationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/service/impl/SyncConfigurationServiceImpl.java
@@ -2,14 +2,13 @@ package org.openmrs.module.sync2.api.service.impl;
 
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.sync2.api.exceptions.SyncException;
 import org.openmrs.module.sync2.api.model.configuration.ClassConfiguration;
+import org.openmrs.module.sync2.api.model.configuration.SyncConfiguration;
 import org.openmrs.module.sync2.api.model.configuration.SyncMethodConfiguration;
 import org.openmrs.module.sync2.api.model.enums.SyncOperation;
-import org.openmrs.module.sync2.api.service.SyncConfigurationService;
-import org.openmrs.module.sync2.api.exceptions.SyncException;
-import org.openmrs.module.sync2.api.model.configuration.SyncConfiguration;
 import org.openmrs.module.sync2.api.scheduler.SyncSchedulerService;
-import org.openmrs.module.sync2.api.utils.SyncUtils;
+import org.openmrs.module.sync2.api.service.SyncConfigurationService;
 import org.openmrs.module.sync2.api.validator.Errors;
 import org.openmrs.module.sync2.api.validator.SyncConfigurationValidator;
 import org.openmrs.util.OpenmrsUtil;
@@ -26,10 +25,10 @@ import static org.openmrs.module.sync2.SyncConstants.SYNC2_PATH_TO_DEFAULT_CONFI
 import static org.openmrs.module.sync2.api.model.enums.ResourcePathType.ABSOLUTE;
 import static org.openmrs.module.sync2.api.model.enums.ResourcePathType.RELATIVE;
 import static org.openmrs.module.sync2.api.utils.SyncConfigurationUtils.customConfigExists;
-import static org.openmrs.module.sync2.api.utils.SyncConfigurationUtils.parseJsonFileToSyncConfiguration;
-import static org.openmrs.module.sync2.api.utils.SyncConfigurationUtils.writeSyncConfigurationToJsonFile;
 import static org.openmrs.module.sync2.api.utils.SyncConfigurationUtils.isValidateJson;
+import static org.openmrs.module.sync2.api.utils.SyncConfigurationUtils.parseJsonFileToSyncConfiguration;
 import static org.openmrs.module.sync2.api.utils.SyncConfigurationUtils.parseJsonStringToSyncConfiguration;
+import static org.openmrs.module.sync2.api.utils.SyncConfigurationUtils.writeSyncConfigurationToJsonFile;
 
 @Component("sync2.syncConfigurationService")
 public class SyncConfigurationServiceImpl implements SyncConfigurationService {

--- a/api/src/main/java/org/openmrs/module/sync2/api/service/impl/SyncPullServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/service/impl/SyncPullServiceImpl.java
@@ -2,6 +2,7 @@ package org.openmrs.module.sync2.api.service.impl;
 
 import org.openmrs.module.sync2.api.exceptions.SyncException;
 import org.openmrs.module.sync2.api.model.SyncObject;
+import org.openmrs.module.sync2.api.model.enums.SyncOperation;
 import org.openmrs.module.sync2.api.service.ParentObjectHashcodeService;
 import org.openmrs.module.sync2.api.service.SyncAuditService;
 import org.openmrs.module.sync2.api.service.SyncPullService;
@@ -109,8 +110,8 @@ public class SyncPullServiceImpl extends AbstractSynchronizationService implemen
     }
 
     @Override
-    protected String getOperation() {
-        return PULL_OPERATION;
+    protected SyncOperation getOperation() {
+        return SyncOperation.PULL;
     }
 
     @Override
@@ -136,7 +137,7 @@ public class SyncPullServiceImpl extends AbstractSynchronizationService implemen
     @Override
     public AuditMessage pullAndSaveObjectFromParent(String category, Map<String, String> resourceLinks,
                                                   String action) {
-        String clientName = SyncUtils.selectAppropriateClientName(resourceLinks);
+        String clientName = SyncUtils.selectAppropriateClientName(resourceLinks, category, getOperation());
         String uuid = extractUUIDFromResourceLinks(resourceLinks);
         return pullAndSaveObjectFromParent(category, resourceLinks, action, clientName, uuid);
     }

--- a/api/src/main/java/org/openmrs/module/sync2/api/service/impl/SyncPushServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/service/impl/SyncPushServiceImpl.java
@@ -2,6 +2,7 @@ package org.openmrs.module.sync2.api.service.impl;
 
 import org.openmrs.module.sync2.api.exceptions.SyncException;
 import org.openmrs.module.sync2.api.model.SyncObject;
+import org.openmrs.module.sync2.api.model.enums.SyncOperation;
 import org.openmrs.module.sync2.api.service.ParentObjectHashcodeService;
 import org.openmrs.module.sync2.api.service.SyncAuditService;
 import org.openmrs.module.sync2.api.service.SyncPushService;
@@ -114,8 +115,8 @@ public class SyncPushServiceImpl extends AbstractSynchronizationService implemen
     }
 
     @Override
-    protected String getOperation() {
-        return PUSH_OPERATION;
+    protected SyncOperation getOperation() {
+        return SyncOperation.PUSH;
     }
 
     @Override
@@ -136,7 +137,7 @@ public class SyncPushServiceImpl extends AbstractSynchronizationService implemen
     @Override
     public AuditMessage readAndPushObjectToParent(String category, Map<String, String> resourceLinks,
             String action) {
-        String clientName = SyncUtils.selectAppropriateClientName(resourceLinks);
+        String clientName = SyncUtils.selectAppropriateClientName(resourceLinks, category, getOperation());
         String uuid = extractUUIDFromResourceLinks(resourceLinks);
         return readAndPushObjectToParent(category, resourceLinks, action, clientName, uuid);
     }

--- a/api/src/main/java/org/openmrs/module/sync2/api/service/impl/SyncPushServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/service/impl/SyncPushServiceImpl.java
@@ -20,7 +20,6 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 import java.util.Map;
 
-import static org.openmrs.module.sync2.SyncConstants.PUSH_OPERATION;
 import static org.openmrs.module.sync2.api.model.enums.OpenMRSSyncInstance.CHILD;
 import static org.openmrs.module.sync2.api.model.enums.OpenMRSSyncInstance.PARENT;
 import static org.openmrs.module.sync2.api.utils.SyncUtils.getPullUrl;

--- a/api/src/main/java/org/openmrs/module/sync2/api/sync/SyncClient.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/sync/SyncClient.java
@@ -126,7 +126,7 @@ public class SyncClient {
 		Class<?> clazz = helper.resolveClassByCategory(category);
 
 		RequestEntity request = helper.retrieveRequest(resourceUrl);
-		if (!SyncUtils.clientHasSpecificAddress(clientName, instance)) {
+		if (shouldWrappMessage(clientName, instance)) {
 			request = sendRequest(category, destinationUrl, clientName, new InnerRequest(request));
 		}
 		return exchange(request, clazz).getBody();
@@ -137,7 +137,7 @@ public class SyncClient {
 		ClientHelper helper = ClientHelperFactory.createClient(clientName);
 
 		RequestEntity request = helper.createRequest(resourceUrl, object);
-		if (!SyncUtils.clientHasSpecificAddress(clientName, instance)) {
+		if (shouldWrappMessage(clientName, instance)) {
 			request = sendRequest(category, destinationUrl, clientName, new InnerRequest(request));
 		}
 		return exchange(request, String.class);
@@ -148,7 +148,7 @@ public class SyncClient {
 		ClientHelper helper = ClientHelperFactory.createClient(clientName);
 
 		RequestEntity request = helper.createRequest(resourceUrl, uuid);
-		if (!SyncUtils.clientHasSpecificAddress(clientName, instance)) {
+		if (shouldWrappMessage(clientName, instance)) {
 			request = sendRequest(category, destinationUrl, clientName, new InnerRequest(request));
 		}
 		return exchange(request, String.class);
@@ -159,7 +159,7 @@ public class SyncClient {
 		ClientHelper helper = ClientHelperFactory.createClient(clientName);
 
 		RequestEntity request = helper.createRequest(resourceUrl, object);
-		if (!SyncUtils.clientHasSpecificAddress(clientName, instance)) {
+		if (shouldWrappMessage(clientName, instance)) {
 			request = sendRequest(category, destinationUrl, clientName, new InnerRequest(request));
 		}
 		return exchange(request, String.class);
@@ -182,6 +182,10 @@ public class SyncClient {
 		wrapper.setRequest(request);
 
 		return new RequestEntity<>(wrapper, HttpMethod.POST, new URI(destinationUrl));
+	}
+
+	private boolean shouldWrappMessage(String clientName, OpenMRSSyncInstance instance) {
+		return !SyncUtils.clientHasSpecificAddress(clientName, instance);
 	}
 
 	private String getDestinationUri(OpenMRSSyncInstance instance, String clientName) {

--- a/api/src/main/java/org/openmrs/module/sync2/api/utils/SyncAuditUtils.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/utils/SyncAuditUtils.java
@@ -10,11 +10,11 @@ import static org.openmrs.module.sync2.api.utils.SyncUtils.getParentBaseUrl;
 
 public class SyncAuditUtils {
 
-    public static AuditMessage prepareBaseAuditMessage(String operation) {
+    public static AuditMessage prepareBaseAuditMessage(String operation, String clientName) {
         AuditMessage auditMessage = new AuditMessage();
         auditMessage.setTimestamp(new Timestamp(System.currentTimeMillis()));
         auditMessage.setOperation(operation);
-        auditMessage.setParentUrl(getParentBaseUrl());
+        auditMessage.setParentUrl(getParentBaseUrl(clientName));
         auditMessage.setLocalUrl(getLocalBaseUrl());
         auditMessage.setCreatorInstanceId(getLocalInstanceId());
 

--- a/api/src/main/java/org/openmrs/module/sync2/api/utils/SyncConfigurationUtils.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/utils/SyncConfigurationUtils.java
@@ -8,16 +8,16 @@ import org.codehaus.jackson.map.ObjectWriter;
 import org.codehaus.jackson.util.DefaultPrettyPrinter;
 import org.openmrs.module.sync2.api.exceptions.SyncException;
 import org.openmrs.module.sync2.api.exceptions.SyncValidationException;
+import org.openmrs.module.sync2.api.model.configuration.ClientConfiguration;
 import org.openmrs.module.sync2.api.model.configuration.SyncConfiguration;
 import org.openmrs.module.sync2.api.model.enums.ResourcePathType;
 import org.openmrs.module.sync2.api.validator.Errors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.LinkedHashMap;
 
 import static org.openmrs.module.sync2.api.model.enums.ResourcePathType.ABSOLUTE;
 
@@ -118,5 +118,15 @@ public class SyncConfigurationUtils {
 
     public static boolean customConfigExists(String path) {
         return new File(path).exists();
+    }
+
+    public static ClientConfiguration getClientConfiguration(String clientName) {
+        ClientConfiguration configuration = null;
+        LinkedHashMap<String, ClientConfiguration> availableConfigurations = SyncUtils.getSyncConfigurationService()
+                .getSyncConfiguration().getGeneral().getClients();
+        if (!availableConfigurations.isEmpty()) {
+            configuration = availableConfigurations.get(clientName);
+        }
+        return configuration;
     }
 }

--- a/api/src/main/java/org/openmrs/module/sync2/api/utils/SyncUtils.java
+++ b/api/src/main/java/org/openmrs/module/sync2/api/utils/SyncUtils.java
@@ -32,7 +32,6 @@ import javax.xml.bind.JAXBException;
 import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -71,13 +70,9 @@ public class SyncUtils {
 
 	public static String getSpecificClientAddress(String clientName) {
 		String address = null;
-		LinkedHashMap<String, ClientConfiguration> availableConfigurations = getSyncConfigurationService()
-				.getSyncConfiguration().getGeneral().getClients();
-		if (!availableConfigurations.isEmpty()) {
-			ClientConfiguration configuration = availableConfigurations.get(clientName);
-			if (configuration != null) {
-				address = configuration.getHostAddress();
-			}
+		ClientConfiguration configuration = SyncConfigurationUtils.getClientConfiguration(clientName);
+		if (configuration != null) {
+			address = configuration.getHostAddress();
 		}
 		return address;
 	}
@@ -111,26 +106,18 @@ public class SyncUtils {
 
 	public static String getClientSpecificLogin(String clientName) {
 		String login = null;
-		LinkedHashMap<String, ClientConfiguration> availableConfigurations = getSyncConfigurationService()
-				.getSyncConfiguration().getGeneral().getClients();
-		if (!availableConfigurations.isEmpty()) {
-			ClientConfiguration configuration = availableConfigurations.get(clientName);
-			if (configuration != null) {
-				login = configuration.getLogin();
-			}
+		ClientConfiguration configuration = SyncConfigurationUtils.getClientConfiguration(clientName);
+		if (configuration != null) {
+			login = configuration.getLogin();
 		}
 		return login;
 	}
 
 	public static String getClientSpecificPassword(String clientName) {
 		String password = null;
-		LinkedHashMap<String, ClientConfiguration> availableConfigurations = getSyncConfigurationService()
-				.getSyncConfiguration().getGeneral().getClients();
-		if (!availableConfigurations.isEmpty()) {
-			ClientConfiguration configuration = availableConfigurations.get(clientName);
-			if (configuration != null) {
-				password = configuration.getPassword();
-			}
+		ClientConfiguration configuration = SyncConfigurationUtils.getClientConfiguration(clientName);
+		if (configuration != null) {
+			password = configuration.getPassword();
 		}
 		return password;
 	}
@@ -195,7 +182,7 @@ public class SyncUtils {
 	private static String getPushPath(String pathWithId) {
 		String result = null;
 		if (pathWithId.contains("/")) {
-			result = pathWithId.substring(0, pathWithId.lastIndexOf("/"));
+			result = pathWithId.substring(SyncConstants.ZERO, pathWithId.lastIndexOf("/"));
 		} else {
 			result = pathWithId;
 		}

--- a/api/src/test/java/org/openmrs/module/sync2/api/mother/SyncConfigurationMother.java
+++ b/api/src/test/java/org/openmrs/module/sync2/api/mother/SyncConfigurationMother.java
@@ -2,6 +2,7 @@ package org.openmrs.module.sync2.api.mother;
 
 import org.openmrs.module.sync2.SyncConstants;
 import org.openmrs.module.sync2.api.model.configuration.ClassConfiguration;
+import org.openmrs.module.sync2.api.model.configuration.ClientConfiguration;
 import org.openmrs.module.sync2.api.model.configuration.GeneralConfiguration;
 import org.openmrs.module.sync2.api.model.configuration.SyncConfiguration;
 import org.openmrs.module.sync2.api.model.configuration.SyncMethodConfiguration;
@@ -9,13 +10,16 @@ import org.openmrs.module.sync2.api.model.configuration.WhitelistConfiguration;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 public abstract class SyncConfigurationMother {
 
 	private static final String SAMPLE_LOCAL_INSTANCE_ID = "localInstanceId";
 
-	public static SyncConfiguration creteInstance(boolean withWhiteList) {
+	private static final String CLIENT_SPECIFIC_ADDRESS = "http://address.org";
+
+	public static SyncConfiguration creteInstance(boolean withWhiteList, boolean clientsConf) {
 		SyncConfiguration configuration = createInstance();
 
 		if (withWhiteList) {
@@ -24,6 +28,10 @@ public abstract class SyncConfigurationMother {
 			WhitelistConfiguration whitelist = new WhitelistConfiguration(true, instanceIds);
 			configuration.setWhitelist(whitelist);
 		}
+		if (clientsConf) {
+			configuration.getGeneral().getClients().put(SyncConstants.REST_CLIENT,
+					new ClientConfiguration(CLIENT_SPECIFIC_ADDRESS));
+		}
 
 		return configuration;
 	}
@@ -31,7 +39,7 @@ public abstract class SyncConfigurationMother {
 	private static SyncConfiguration createInstance() {
 		SyncConfiguration configuration = new SyncConfiguration();
 		GeneralConfiguration general = new GeneralConfiguration("", "defaultAddress",
-				SAMPLE_LOCAL_INSTANCE_ID, false, false);
+				SAMPLE_LOCAL_INSTANCE_ID, false, false, new LinkedHashMap<>());
 		configuration.setGeneral(general);
 
 		ClassConfiguration locationClass = new ClassConfiguration("Location",

--- a/api/src/test/java/org/openmrs/module/sync2/api/mother/SyncConfigurationMother.java
+++ b/api/src/test/java/org/openmrs/module/sync2/api/mother/SyncConfigurationMother.java
@@ -1,0 +1,51 @@
+package org.openmrs.module.sync2.api.mother;
+
+import org.openmrs.module.sync2.SyncConstants;
+import org.openmrs.module.sync2.api.model.configuration.ClassConfiguration;
+import org.openmrs.module.sync2.api.model.configuration.GeneralConfiguration;
+import org.openmrs.module.sync2.api.model.configuration.SyncConfiguration;
+import org.openmrs.module.sync2.api.model.configuration.SyncMethodConfiguration;
+import org.openmrs.module.sync2.api.model.configuration.WhitelistConfiguration;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public abstract class SyncConfigurationMother {
+
+	private static final String SAMPLE_LOCAL_INSTANCE_ID = "localInstanceId";
+
+	public static SyncConfiguration creteInstance(boolean withWhiteList) {
+		SyncConfiguration configuration = createInstance();
+
+		if (withWhiteList) {
+			List<String> instanceIds = new ArrayList<>();
+			instanceIds.add("childInstanceId");
+			WhitelistConfiguration whitelist = new WhitelistConfiguration(true, instanceIds);
+			configuration.setWhitelist(whitelist);
+		}
+
+		return configuration;
+	}
+
+	private static SyncConfiguration createInstance() {
+		SyncConfiguration configuration = new SyncConfiguration();
+		GeneralConfiguration general = new GeneralConfiguration("", "defaultAddress",
+				SAMPLE_LOCAL_INSTANCE_ID, false, false);
+		configuration.setGeneral(general);
+
+		ClassConfiguration locationClass = new ClassConfiguration("Location",
+				"location", "org.openmrs.Location", true, SyncConstants.FHIR_CLIENT);
+		ClassConfiguration observationClass = new ClassConfiguration("Observation",
+				"observation", "org.openmrs.Obs", true);
+		List<ClassConfiguration> classes = Arrays.asList(locationClass, observationClass);
+
+		SyncMethodConfiguration push = new SyncMethodConfiguration(true, 12, classes);
+		configuration.setPush(push);
+
+		SyncMethodConfiguration pull = new SyncMethodConfiguration(true, 12, classes);
+		configuration.setPull(pull);
+		return configuration;
+	}
+
+}

--- a/api/src/test/java/org/openmrs/module/sync2/api/mother/SyncConfigurationMother.java
+++ b/api/src/test/java/org/openmrs/module/sync2/api/mother/SyncConfigurationMother.java
@@ -19,6 +19,10 @@ public abstract class SyncConfigurationMother {
 
 	private static final String CLIENT_SPECIFIC_ADDRESS = "http://address.org";
 
+	private static final String CLIENT_LOGIN = "clientLogin";
+
+	private static final String CLIENT_PASSWORD = "clientPassword";
+
 	public static SyncConfiguration creteInstance(boolean withWhiteList, boolean clientsConf) {
 		SyncConfiguration configuration = createInstance();
 
@@ -30,7 +34,7 @@ public abstract class SyncConfigurationMother {
 		}
 		if (clientsConf) {
 			configuration.getGeneral().getClients().put(SyncConstants.REST_CLIENT,
-					new ClientConfiguration(CLIENT_SPECIFIC_ADDRESS));
+					new ClientConfiguration(CLIENT_SPECIFIC_ADDRESS, CLIENT_LOGIN, CLIENT_PASSWORD));
 		}
 
 		return configuration;

--- a/api/src/test/java/org/openmrs/module/sync2/api/service/impl/SyncConfigurationServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/sync2/api/service/impl/SyncConfigurationServiceImplTest.java
@@ -42,7 +42,7 @@ public class SyncConfigurationServiceImplTest {
 
     @Test
     public void saveConfiguration_shouldLoadTheSyncConfigurationFromObjectCorrectly() throws SyncException {
-        final SyncConfiguration expectedSyncConfiguration = SyncConfigurationMother.creteInstance(true);
+        final SyncConfiguration expectedSyncConfiguration = SyncConfigurationMother.creteInstance(true, false);
 
         SyncConfiguration syncConfiguration = parseJsonFileToSyncConfiguration(SAMPLE_FEED_CONFIGURATION_PATH, RELATIVE);
         sync2ConfigurationService.saveConfiguration(syncConfiguration);
@@ -52,7 +52,7 @@ public class SyncConfigurationServiceImplTest {
 
     @Test
     public void saveConfiguration_shouldLoadTheSyncConfigurationFromStringCorrectly() throws SyncException {
-        final SyncConfiguration expectedSyncConfiguration = SyncConfigurationMother.creteInstance(false);
+        final SyncConfiguration expectedSyncConfiguration = SyncConfigurationMother.creteInstance(false, true);
 
         String json = readResourceFile(SAMPLE_FEED_CONFIGURATION_PATH2);
         sync2ConfigurationService.saveConfiguration(json);
@@ -62,7 +62,7 @@ public class SyncConfigurationServiceImplTest {
 
     @Test
     public void saveConfiguration_shouldSavedConfigurationWithDefaultWhitelist() throws SyncException {
-        final SyncConfiguration expectedSyncConfiguration = SyncConfigurationMother.creteInstance(false);
+        final SyncConfiguration expectedSyncConfiguration = SyncConfigurationMother.creteInstance(false, false);
 
         String json = readResourceFile(NO_WHITELIST_PROVIDED_CONFIGURATION_PATH);
         sync2ConfigurationService.saveConfiguration(json);

--- a/api/src/test/java/org/openmrs/module/sync2/api/service/impl/SyncConfigurationServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/sync2/api/service/impl/SyncConfigurationServiceImplTest.java
@@ -12,7 +12,6 @@ import org.openmrs.module.sync2.api.model.configuration.GeneralConfiguration;
 import org.openmrs.module.sync2.api.model.configuration.SyncConfiguration;
 import org.openmrs.module.sync2.api.model.configuration.SyncMethodConfiguration;
 import org.openmrs.module.sync2.api.model.configuration.WhitelistConfiguration;
-import org.openmrs.module.sync2.api.model.enums.ResourcePathType;
 import org.openmrs.module.sync2.api.scheduler.SyncSchedulerService;
 import org.openmrs.module.sync2.api.scheduler.impl.SyncSchedulerServiceImpl;
 
@@ -57,7 +56,7 @@ public class SyncConfigurationServiceImplTest {
         expectedSyncConfiguration.setGeneral(general);
 
         ClassConfiguration locationClass = new ClassConfiguration("Location",
-                "location", "org.openmrs.Location", true);
+                "location", "org.openmrs.Location", true, "REST");
         ClassConfiguration observationClass = new ClassConfiguration("Observation",
                 "observation", "org.openmrs.Obs", true);
         List<ClassConfiguration> classes = Arrays.asList(locationClass, observationClass);

--- a/api/src/test/java/org/openmrs/module/sync2/api/service/impl/SyncConfigurationServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/sync2/api/service/impl/SyncConfigurationServiceImplTest.java
@@ -5,19 +5,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.openmrs.module.sync2.api.service.SyncConfigurationService;
 import org.openmrs.module.sync2.api.exceptions.SyncException;
-import org.openmrs.module.sync2.api.model.configuration.ClassConfiguration;
-import org.openmrs.module.sync2.api.model.configuration.GeneralConfiguration;
 import org.openmrs.module.sync2.api.model.configuration.SyncConfiguration;
-import org.openmrs.module.sync2.api.model.configuration.SyncMethodConfiguration;
 import org.openmrs.module.sync2.api.model.configuration.WhitelistConfiguration;
+import org.openmrs.module.sync2.api.mother.SyncConfigurationMother;
 import org.openmrs.module.sync2.api.scheduler.SyncSchedulerService;
 import org.openmrs.module.sync2.api.scheduler.impl.SyncSchedulerServiceImpl;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import org.openmrs.module.sync2.api.service.SyncConfigurationService;
 
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.openmrs.module.sync2.api.model.enums.ResourcePathType.RELATIVE;
@@ -30,7 +24,6 @@ public class SyncConfigurationServiceImplTest {
     private static final String SAMPLE_FEED_CONFIGURATION_PATH2 = "sampleSyncConfiguration2.json";
     private static final String NO_WHITELIST_PROVIDED_CONFIGURATION_PATH = "noWhitelistConfiguration.json";
 
-    private static final String SAMPLE_LOCAL_INSTANCE_ID = "localInstanceId";
     private static final String SAMPLE_LOCAL_INSTANCE_ID_2 = "localInstanceId2";
     
     @Mock
@@ -49,28 +42,7 @@ public class SyncConfigurationServiceImplTest {
 
     @Test
     public void saveConfiguration_shouldLoadTheSyncConfigurationFromObjectCorrectly() throws SyncException {
-        final SyncConfiguration expectedSyncConfiguration = new SyncConfiguration();
-
-        GeneralConfiguration general = new GeneralConfiguration("", "defaultAddress",
-                SAMPLE_LOCAL_INSTANCE_ID, false, false);
-        expectedSyncConfiguration.setGeneral(general);
-
-        ClassConfiguration locationClass = new ClassConfiguration("Location",
-                "location", "org.openmrs.Location", true, "REST");
-        ClassConfiguration observationClass = new ClassConfiguration("Observation",
-                "observation", "org.openmrs.Obs", true);
-        List<ClassConfiguration> classes = Arrays.asList(locationClass, observationClass);
-
-        SyncMethodConfiguration push = new SyncMethodConfiguration(true, 12, classes);
-        expectedSyncConfiguration.setPush(push);
-
-        SyncMethodConfiguration pull = new SyncMethodConfiguration(true, 12, classes);
-        expectedSyncConfiguration.setPull(pull);
-
-        List<String> instanceIds = new ArrayList<>();
-        instanceIds.add("childInstanceId");
-        WhitelistConfiguration whitelist = new WhitelistConfiguration(true, instanceIds);
-        expectedSyncConfiguration.setWhitelist(whitelist);
+        final SyncConfiguration expectedSyncConfiguration = SyncConfigurationMother.creteInstance(true);
 
         SyncConfiguration syncConfiguration = parseJsonFileToSyncConfiguration(SAMPLE_FEED_CONFIGURATION_PATH, RELATIVE);
         sync2ConfigurationService.saveConfiguration(syncConfiguration);
@@ -80,27 +52,7 @@ public class SyncConfigurationServiceImplTest {
 
     @Test
     public void saveConfiguration_shouldLoadTheSyncConfigurationFromStringCorrectly() throws SyncException {
-        final SyncConfiguration expectedSyncConfiguration = new SyncConfiguration();
-
-        GeneralConfiguration general = new GeneralConfiguration("", "defaultAddress2",
-                SAMPLE_LOCAL_INSTANCE_ID_2, false, false);
-        expectedSyncConfiguration.setGeneral(general);
-
-        ClassConfiguration encounterClass = new ClassConfiguration("Encounter",
-                "encounter", "org.openmrs.Encounter", false);
-        ClassConfiguration visitClass = new ClassConfiguration("Visit",
-                "visit", "org.openmrs.Visit", false);
-
-        List<ClassConfiguration> classes = Arrays.asList(encounterClass, visitClass);
-
-        SyncMethodConfiguration push = new SyncMethodConfiguration(false, 24, classes);
-        expectedSyncConfiguration.setPush(push);
-
-        SyncMethodConfiguration pull = new SyncMethodConfiguration(false, 24, classes);
-        expectedSyncConfiguration.setPull(pull);
-
-        WhitelistConfiguration whitelist = new WhitelistConfiguration(false, new ArrayList<>());
-        expectedSyncConfiguration.setWhitelist(whitelist);
+        final SyncConfiguration expectedSyncConfiguration = SyncConfigurationMother.creteInstance(false);
 
         String json = readResourceFile(SAMPLE_FEED_CONFIGURATION_PATH2);
         sync2ConfigurationService.saveConfiguration(json);
@@ -110,27 +62,7 @@ public class SyncConfigurationServiceImplTest {
 
     @Test
     public void saveConfiguration_shouldSavedConfigurationWithDefaultWhitelist() throws SyncException {
-        final SyncConfiguration expectedSyncConfiguration = new SyncConfiguration();
-
-        GeneralConfiguration general = new GeneralConfiguration("", "defaultAddress2",
-                SAMPLE_LOCAL_INSTANCE_ID_2, false, false);
-        expectedSyncConfiguration.setGeneral(general);
-
-        ClassConfiguration encounterClass = new ClassConfiguration("Encounter",
-                "encounter", "org.openmrs.Encounter", false);
-        ClassConfiguration visitClass = new ClassConfiguration("Visit",
-                "visit", "org.openmrs.Visit", false);
-
-        List<ClassConfiguration> classes = Arrays.asList(encounterClass, visitClass);
-
-        SyncMethodConfiguration push = new SyncMethodConfiguration(false, 24, classes);
-        expectedSyncConfiguration.setPush(push);
-
-        SyncMethodConfiguration pull = new SyncMethodConfiguration(false, 24, classes);
-        expectedSyncConfiguration.setPull(pull);
-
-        WhitelistConfiguration whitelist = new WhitelistConfiguration(false, new ArrayList<>());
-        expectedSyncConfiguration.setWhitelist(whitelist);
+        final SyncConfiguration expectedSyncConfiguration = SyncConfigurationMother.creteInstance(false);
 
         String json = readResourceFile(NO_WHITELIST_PROVIDED_CONFIGURATION_PATH);
         sync2ConfigurationService.saveConfiguration(json);

--- a/api/src/test/java/org/openmrs/module/sync2/api/sync/SyncClientTest.java
+++ b/api/src/test/java/org/openmrs/module/sync2/api/sync/SyncClientTest.java
@@ -4,6 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.BDDMockito;
+import org.mockito.Mockito;
 import org.openmrs.Encounter;
 import org.openmrs.Obs;
 import org.openmrs.Order;
@@ -86,7 +87,7 @@ public class SyncClientTest {
         when(ContextUtils.getConversionService()).thenReturn(new DefaultConversionService());
 
         mockStatic(SyncUtils.class);
-        when(SyncUtils.getParentBaseUrl()).thenReturn(PARENT_FEED_LOCATION);
+        when(SyncUtils.getParentBaseUrl(Mockito.anyString())).thenReturn(PARENT_FEED_LOCATION);
 
         expectedPatient = createPatient();
         expectedVisit = createVisit();
@@ -121,16 +122,16 @@ public class SyncClientTest {
         SyncClient syncClient =  PowerMockito.spy(new SyncClient());
         PowerMockito.doReturn(createPatient())
                 .when(syncClient, "retrieveObject", PATIENT_CATEGORY, REST_FULL_RESOURCE_URL, PARENT_DESTINATION_URL,
-                        REST_CLIENT_KEY);
+                        REST_CLIENT_KEY, PARENT);
         PowerMockito.doReturn(createVisit())
                 .when(syncClient, "retrieveObject", VISIT_CATEGORY, REST_FULL_RESOURCE_URL, PARENT_DESTINATION_URL,
-                        REST_CLIENT_KEY);
+                        REST_CLIENT_KEY, PARENT);
         PowerMockito.doReturn(createPatient())
                 .when(syncClient, "retrieveObject", PATIENT_CATEGORY, FHIR_FULL_RESOURCE_URL, PARENT_DESTINATION_URL,
-                        FHIR_CLIENT_KEY);
+                        FHIR_CLIENT_KEY, PARENT);
         PowerMockito.doReturn(createVisit())
                 .when(syncClient, "retrieveObject", VISIT_CATEGORY, FHIR_FULL_RESOURCE_URL, PARENT_DESTINATION_URL,
-                        FHIR_CLIENT_KEY);
+                        FHIR_CLIENT_KEY, PARENT);
         whenNew(SyncClient.class).withNoArguments().thenReturn(syncClient);
     }
     

--- a/api/src/test/java/org/openmrs/module/sync2/api/utils/SyncConfigurationUtilsTest.java
+++ b/api/src/test/java/org/openmrs/module/sync2/api/utils/SyncConfigurationUtilsTest.java
@@ -50,7 +50,7 @@ public class SyncConfigurationUtilsTest {
         EXPECTED_CONFIGURATION.setGeneral(general);
 
         ClassConfiguration locationClass = new ClassConfiguration("Location",
-                "location", "org.openmrs.Location", true);
+                "location", "org.openmrs.Location", true, "REST");
         ClassConfiguration observationClass = new ClassConfiguration("Observation",
                 "observation", "org.openmrs.Obs", true);
         List<ClassConfiguration> classes = Arrays.asList(locationClass, observationClass);
@@ -119,7 +119,7 @@ public class SyncConfigurationUtilsTest {
 
     @Test
     public void shouldWriteSyncConfigurationToJsonString() throws SyncException {
-        String result = writeSyncConfigurationToJsonString(EXPECTED_CONFIGURATION);
+        String result = writeSyncConfigurationToJsonString(EXPECTED_CONFIGURATION) + '\n';
         String expected = readResourceFile(SAMPLE_SYNC_CONFIGURATION_PATH);
 
         Assert.assertEquals(expected, result);
@@ -133,7 +133,7 @@ public class SyncConfigurationUtilsTest {
         writeSyncConfigurationToJsonFile(EXPECTED_CONFIGURATION, path);
 
         String expected = readResourceFile(SAMPLE_SYNC_CONFIGURATION_PATH);
-        String result = readResourceFileAbsolutePath(path);
+        String result = readResourceFileAbsolutePath(path) + '\n';
 
         Assert.assertEquals(expected, result);
     }

--- a/api/src/test/java/org/openmrs/module/sync2/api/utils/SyncConfigurationUtilsTest.java
+++ b/api/src/test/java/org/openmrs/module/sync2/api/utils/SyncConfigurationUtilsTest.java
@@ -32,7 +32,8 @@ public class SyncConfigurationUtilsTest {
     private static final String SAMPLE_PRETTY_SERIALIZED_MAP = "samplePrettySerializedMap.json";
 
     private static final String NOT_EXISTING_FILE_PATH = "pathToNotExistingFile";
-    private static final SyncConfiguration EXPECTED_CONFIGURATION = SyncConfigurationMother.creteInstance(true);
+    private static final SyncConfiguration EXPECTED_CONFIGURATION = SyncConfigurationMother
+            .creteInstance(true, false);
 
     @Test
     public void readResourceFile_shouldReadSampleFile() throws SyncException {

--- a/api/src/test/java/org/openmrs/module/sync2/api/utils/SyncConfigurationUtilsTest.java
+++ b/api/src/test/java/org/openmrs/module/sync2/api/utils/SyncConfigurationUtilsTest.java
@@ -1,33 +1,26 @@
 package org.openmrs.module.sync2.api.utils;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.module.sync2.api.exceptions.SyncException;
-import org.openmrs.module.sync2.api.model.configuration.ClassConfiguration;
-import org.openmrs.module.sync2.api.model.configuration.GeneralConfiguration;
 import org.openmrs.module.sync2.api.model.configuration.SyncConfiguration;
-import org.openmrs.module.sync2.api.model.configuration.SyncMethodConfiguration;
-import org.openmrs.module.sync2.api.model.configuration.WhitelistConfiguration;
+import org.openmrs.module.sync2.api.mother.SyncConfigurationMother;
 import org.openmrs.util.OpenmrsUtil;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.openmrs.module.sync2.SyncConstants.CONFIGURATION_DIR;
 import static org.openmrs.module.sync2.api.model.enums.ResourcePathType.RELATIVE;
+import static org.openmrs.module.sync2.api.utils.SyncConfigurationUtils.isValidateJson;
 import static org.openmrs.module.sync2.api.utils.SyncConfigurationUtils.parseJsonFileToSyncConfiguration;
 import static org.openmrs.module.sync2.api.utils.SyncConfigurationUtils.parseJsonStringToSyncConfiguration;
 import static org.openmrs.module.sync2.api.utils.SyncConfigurationUtils.readResourceFile;
-import static org.openmrs.module.sync2.api.utils.SyncConfigurationUtils.isValidateJson;
 import static org.openmrs.module.sync2.api.utils.SyncConfigurationUtils.readResourceFileAbsolutePath;
+import static org.openmrs.module.sync2.api.utils.SyncConfigurationUtils.resourceFileExists;
 import static org.openmrs.module.sync2.api.utils.SyncConfigurationUtils.writeSyncConfigurationToJsonFile;
 import static org.openmrs.module.sync2.api.utils.SyncConfigurationUtils.writeSyncConfigurationToJsonString;
-import static org.openmrs.module.sync2.api.utils.SyncConfigurationUtils.resourceFileExists;
 import static org.openmrs.module.sync2.api.utils.SyncUtils.prettySerialize;
 import static org.openmrs.module.sync2.api.utils.SyncUtils.serialize;
 
@@ -39,33 +32,7 @@ public class SyncConfigurationUtilsTest {
     private static final String SAMPLE_PRETTY_SERIALIZED_MAP = "samplePrettySerializedMap.json";
 
     private static final String NOT_EXISTING_FILE_PATH = "pathToNotExistingFile";
-    private static final SyncConfiguration EXPECTED_CONFIGURATION = new SyncConfiguration();
-    
-    private static final String SAMPLE_LOCAL_INSTANCE_ID = "localInstanceId";
-    
-    @Before
-    public void setUp() {
-        GeneralConfiguration general = new GeneralConfiguration("", "defaultAddress",
-                SAMPLE_LOCAL_INSTANCE_ID, false, false);
-        EXPECTED_CONFIGURATION.setGeneral(general);
-
-        ClassConfiguration locationClass = new ClassConfiguration("Location",
-                "location", "org.openmrs.Location", true, "REST");
-        ClassConfiguration observationClass = new ClassConfiguration("Observation",
-                "observation", "org.openmrs.Obs", true);
-        List<ClassConfiguration> classes = Arrays.asList(locationClass, observationClass);
-
-        SyncMethodConfiguration push = new SyncMethodConfiguration(true, 12, classes);
-        EXPECTED_CONFIGURATION.setPush(push);
-
-        SyncMethodConfiguration pull = new SyncMethodConfiguration(true, 12, classes);
-        EXPECTED_CONFIGURATION.setPull(pull);
-
-        List<String> instanceIds = new ArrayList<>();
-        instanceIds.add("childInstanceId");
-        WhitelistConfiguration whitelist = new WhitelistConfiguration(true, instanceIds);
-        EXPECTED_CONFIGURATION.setWhitelist(whitelist);
-    }
+    private static final SyncConfiguration EXPECTED_CONFIGURATION = SyncConfigurationMother.creteInstance(true);
 
     @Test
     public void readResourceFile_shouldReadSampleFile() throws SyncException {

--- a/api/src/test/java/org/openmrs/module/sync2/api/utils/SyncUtilsTest.java
+++ b/api/src/test/java/org/openmrs/module/sync2/api/utils/SyncUtilsTest.java
@@ -42,7 +42,7 @@ public class SyncUtilsTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         Mockito.when(syncConfigurationServiceImpl.getSyncConfiguration()).thenReturn(
-                SyncConfigurationMother.creteInstance(true));
+                SyncConfigurationMother.creteInstance(true, true));
         Mockito.when(syncConfigurationServiceImpl.getClassConfiguration(Mockito.any(), Mockito.any())).thenCallRealMethod();
 
         Mockito.when(administrationService.getGlobalProperty(SyncConstants.RESOURCE_PREFERRED_CLIENT,

--- a/api/src/test/java/org/openmrs/module/sync2/api/utils/SyncUtilsTest.java
+++ b/api/src/test/java/org/openmrs/module/sync2/api/utils/SyncUtilsTest.java
@@ -3,38 +3,54 @@ package org.openmrs.module.sync2.api.utils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openmrs.module.sync2.api.model.configuration.ClassConfiguration;
-import org.openmrs.module.sync2.api.model.configuration.GeneralConfiguration;
-import org.openmrs.module.sync2.api.model.configuration.SyncConfiguration;
-import org.openmrs.module.sync2.api.model.configuration.SyncMethodConfiguration;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.sync2.SyncConstants;
 import org.openmrs.module.sync2.api.model.enums.AtomfeedTagContent;
+import org.openmrs.module.sync2.api.model.enums.SyncOperation;
+import org.openmrs.module.sync2.api.mother.SyncConfigurationMother;
+import org.openmrs.module.sync2.api.service.SyncConfigurationService;
+import org.openmrs.module.sync2.api.service.impl.SyncConfigurationServiceImpl;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ Context.class })
 public class SyncUtilsTest {
-    
-    private static final SyncConfiguration EXPECTED_CONFIGURATION = new SyncConfiguration();
-    private static final String SAMPLE_LOCAL_INSTANCE_ID = "localInstanceId";
-    
+
+    private static final String GLOBAL_CLIENT = SyncConstants.REST_CLIENT;
+
+    private static final String LOCATION_PREFERRED_CLIENT = SyncConstants.FHIR_CLIENT;
+
+    @Mock
+    private SyncConfigurationServiceImpl syncConfigurationServiceImpl;
+
+    @Mock
+    private AdministrationService administrationService;
+
     @Before
     public void setUp() {
-        GeneralConfiguration general = new GeneralConfiguration("", "defaultAddress",
-                SAMPLE_LOCAL_INSTANCE_ID, false, false);
-        EXPECTED_CONFIGURATION.setGeneral(general);
+        MockitoAnnotations.initMocks(this);
+        Mockito.when(syncConfigurationServiceImpl.getSyncConfiguration()).thenReturn(
+                SyncConfigurationMother.creteInstance(true));
+        Mockito.when(syncConfigurationServiceImpl.getClassConfiguration(Mockito.any(), Mockito.any())).thenCallRealMethod();
 
-        ClassConfiguration locationClass = new ClassConfiguration("Location",
-                "location", "org.openmrs.Location", true);
-        ClassConfiguration observationClass = new ClassConfiguration("Observation",
-                "observation", "org.openmrs.Obs", true);
-        List<ClassConfiguration> classes = Arrays.asList(locationClass, observationClass);
+        Mockito.when(administrationService.getGlobalProperty(SyncConstants.RESOURCE_PREFERRED_CLIENT,
+                SyncConstants.DEFAULT_SYNC_2_CLIENT)).thenReturn(GLOBAL_CLIENT);
 
-        SyncMethodConfiguration push = new SyncMethodConfiguration(true, 12, classes);
-        EXPECTED_CONFIGURATION.setPush(push);
-
-        SyncMethodConfiguration pull = new SyncMethodConfiguration(true, 12, classes);
-        EXPECTED_CONFIGURATION.setPull(pull);
+        PowerMockito.mockStatic(Context.class);
+        PowerMockito.when(Context.getService(SyncConfigurationService.class)).thenReturn(syncConfigurationServiceImpl);
+        PowerMockito.when(Context.getAdministrationService()).thenReturn(administrationService);
     }
 
     @Test
@@ -46,13 +62,13 @@ public class SyncUtilsTest {
         Assert.assertTrue(SyncUtils.checkIfParamIsEventAction("UNVOIDED"));
         Assert.assertTrue(SyncUtils.checkIfParamIsEventAction("DELETED"));
     }
-    
+
     @Test
     public void checkIfParamIsEventAction_shouldReturnFalseIfParamIsNotEventAction() {
         Assert.assertFalse(SyncUtils.checkIfParamIsEventAction("updated"));
         Assert.assertFalse(SyncUtils.checkIfParamIsEventAction("somethingElse"));
     }
-    
+
     @Test
     public void getValueOfAtomfeedEventTag_shouldReturnCategoryDespiteItsOrderInList() {
         final String expected = "patient";
@@ -61,7 +77,7 @@ public class SyncUtilsTest {
         Assert.assertEquals(expected, result1);
         Assert.assertEquals(expected, result2);
     }
-    
+
     @Test
     public void getValueOfAtomfeedEventTag_shouldReturnEventActionDespiteItsOrderInList() {
         final String expected = "CREATED";
@@ -73,13 +89,50 @@ public class SyncUtilsTest {
         Assert.assertEquals(expected, result2);
     }
 
+    @Test
+    public void selectAppropriateClientName_shouldReturnClassClientIfExist() throws Exception {
+        String expected = LOCATION_PREFERRED_CLIENT;
+        String actual = SyncUtils.selectAppropriateClientName(prepareDummyLinksTemplate(), "location",
+                SyncOperation.PULL);
+        Assert.assertNotNull(actual);
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void selectAppropriateClientName_shouldReturnFirstFromLinkTemplateIfGlobalAndClassNotExist() throws Exception {
+        Mockito.when(administrationService.getGlobalProperty(SyncConstants.RESOURCE_PREFERRED_CLIENT,
+                SyncConstants.DEFAULT_SYNC_2_CLIENT)).thenReturn(null);
+
+        String expected = SyncConstants.FHIR_CLIENT;
+        String actual = SyncUtils.selectAppropriateClientName(prepareDummyLinksTemplate(), "observation",
+                SyncOperation.PULL);
+        Assert.assertNotNull(actual);
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void selectAppropriateClientName_shouldReturnGlobalClientIfClassClientNotExist() throws Exception {
+        String expected = GLOBAL_CLIENT;
+        String actual = SyncUtils.selectAppropriateClientName(prepareDummyLinksTemplate(), "observation",
+                SyncOperation.PUSH);
+        Assert.assertNotNull(actual);
+        Assert.assertEquals(expected, actual);
+    }
+
+    private Map<String, String> prepareDummyLinksTemplate() {
+        LinkedHashMap<String, String> result = new LinkedHashMap<>();
+        result.put(SyncConstants.FHIR_CLIENT, "fhirUrl");
+        result.put(SyncConstants.REST_CLIENT, "restUrl");
+        return result;
+    }
+
     private List<Object> prepareDummyAtomfeedTags1() {
         List list = new ArrayList();
         list.add("Category.schemeResolved=null\nCategory.scheme=null\nCategory.term=CREATED\nCategory.label=null\n");
         list.add("Category.schemeResolved=null\nCategory.scheme=null\nCategory.term=patient\nCategory.label=null\n");
         return list;
     }
-    
+
     private List<Object> prepareDummyAtomfeedTags2() {
         List list = new ArrayList();
         list.add("Category.schemeResolved=null\nCategory.scheme=null\nCategory.term=patient\nCategory.label=null\n");

--- a/api/src/test/resources/noWhitelistConfiguration.json
+++ b/api/src/test/resources/noWhitelistConfiguration.json
@@ -4,7 +4,8 @@
     "localFeedLocation" : "defaultAddress",
     "localInstanceId" : "localInstanceId",
     "persistSuccessAudit" : false,
-    "persistFailureAudit" : false
+    "persistFailureAudit" : false,
+    "clients" : { }
   },
   "push" : {
     "enabled" : true,

--- a/api/src/test/resources/noWhitelistConfiguration.json
+++ b/api/src/test/resources/noWhitelistConfiguration.json
@@ -1,37 +1,43 @@
 {
   "general" : {
     "parentFeedLocation" : "",
-    "localFeedLocation" : "defaultAddress2",
-    "localInstanceId" : "localInstanceId2"
+    "localFeedLocation" : "defaultAddress",
+    "localInstanceId" : "localInstanceId",
+    "persistSuccessAudit" : false,
+    "persistFailureAudit" : false
   },
   "push" : {
-    "enabled" : false,
-    "schedule" : 24,
+    "enabled" : true,
+    "schedule" : 12,
     "classes" : [ {
-      "classTitle" : "Encounter",
-      "category" : "encounter",
-      "openMrsClass" : "org.openmrs.Encounter",
-      "enabled" : false
+      "classTitle" : "Location",
+      "category" : "location",
+      "openMrsClass" : "org.openmrs.Location",
+      "enabled" : true,
+      "preferredClient" : "fhir"
     }, {
-      "classTitle" : "Visit",
-      "category" : "visit",
-      "openMrsClass" : "org.openmrs.Visit",
-      "enabled" : false
+      "classTitle" : "Observation",
+      "category" : "observation",
+      "openMrsClass" : "org.openmrs.Obs",
+      "enabled" : true,
+      "preferredClient" : null
     } ]
   },
   "pull" : {
-    "enabled" : false,
-    "schedule" : 24,
+    "enabled" : true,
+    "schedule" : 12,
     "classes" : [ {
-      "classTitle" : "Encounter",
-      "category" : "encounter",
-      "openMrsClass" : "org.openmrs.Encounter",
-      "enabled" : false
+      "classTitle" : "Location",
+      "category" : "location",
+      "openMrsClass" : "org.openmrs.Location",
+      "enabled" : true,
+      "preferredClient" : "fhir"
     }, {
-      "classTitle" : "Visit",
-      "category" : "visit",
-      "openMrsClass" : "org.openmrs.Visit",
-      "enabled" : false
+      "classTitle" : "Observation",
+      "category" : "observation",
+      "openMrsClass" : "org.openmrs.Obs",
+      "enabled" : true,
+      "preferredClient" : null
     } ]
   }
 }

--- a/api/src/test/resources/sampleSyncConfiguration.json
+++ b/api/src/test/resources/sampleSyncConfiguration.json
@@ -4,7 +4,8 @@
     "localFeedLocation" : "defaultAddress",
     "localInstanceId" : "localInstanceId",
     "persistSuccessAudit" : false,
-    "persistFailureAudit" : false
+    "persistFailureAudit" : false,
+    "clients" : { }
   },
   "push" : {
     "enabled" : true,

--- a/api/src/test/resources/sampleSyncConfiguration.json
+++ b/api/src/test/resources/sampleSyncConfiguration.json
@@ -13,12 +13,14 @@
       "classTitle" : "Location",
       "category" : "location",
       "openMrsClass" : "org.openmrs.Location",
-      "enabled" : true
+      "enabled" : true,
+      "preferredClient" : "REST"
     }, {
       "classTitle" : "Observation",
       "category" : "observation",
       "openMrsClass" : "org.openmrs.Obs",
-      "enabled" : true
+      "enabled" : true,
+      "preferredClient" : null
     } ]
   },
   "pull" : {
@@ -28,12 +30,14 @@
       "classTitle" : "Location",
       "category" : "location",
       "openMrsClass" : "org.openmrs.Location",
-      "enabled" : true
+      "enabled" : true,
+      "preferredClient" : "REST"
     }, {
       "classTitle" : "Observation",
       "category" : "observation",
       "openMrsClass" : "org.openmrs.Obs",
-      "enabled" : true
+      "enabled" : true,
+      "preferredClient" : null
     } ]
   },
   "whitelist" : {

--- a/api/src/test/resources/sampleSyncConfiguration.json
+++ b/api/src/test/resources/sampleSyncConfiguration.json
@@ -14,7 +14,7 @@
       "category" : "location",
       "openMrsClass" : "org.openmrs.Location",
       "enabled" : true,
-      "preferredClient" : "REST"
+      "preferredClient" : "fhir"
     }, {
       "classTitle" : "Observation",
       "category" : "observation",
@@ -31,7 +31,7 @@
       "category" : "location",
       "openMrsClass" : "org.openmrs.Location",
       "enabled" : true,
-      "preferredClient" : "REST"
+      "preferredClient" : "fhir"
     }, {
       "classTitle" : "Observation",
       "category" : "observation",

--- a/api/src/test/resources/sampleSyncConfiguration2.json
+++ b/api/src/test/resources/sampleSyncConfiguration2.json
@@ -1,37 +1,43 @@
 {
   "general" : {
     "parentFeedLocation" : "",
-    "localFeedLocation" : "defaultAddress2",
-    "localInstanceId" : "localInstanceId2"
+    "localFeedLocation" : "defaultAddress",
+    "localInstanceId" : "localInstanceId",
+    "persistSuccessAudit" : false,
+    "persistFailureAudit" : false
   },
   "push" : {
-    "enabled" : false,
-    "schedule" : 24,
+    "enabled" : true,
+    "schedule" : 12,
     "classes" : [ {
-      "classTitle" : "Encounter",
-      "category" : "encounter",
-      "openMrsClass" : "org.openmrs.Encounter",
-      "enabled" : false
+      "classTitle" : "Location",
+      "category" : "location",
+      "openMrsClass" : "org.openmrs.Location",
+      "enabled" : true,
+      "preferredClient" : "fhir"
     }, {
-      "classTitle" : "Visit",
-      "category" : "visit",
-      "openMrsClass" : "org.openmrs.Visit",
-      "enabled" : false
+      "classTitle" : "Observation",
+      "category" : "observation",
+      "openMrsClass" : "org.openmrs.Obs",
+      "enabled" : true,
+      "preferredClient" : null
     } ]
   },
   "pull" : {
-    "enabled" : false,
-    "schedule" : 24,
+    "enabled" : true,
+    "schedule" : 12,
     "classes" : [ {
-      "classTitle" : "Encounter",
-      "category" : "encounter",
-      "openMrsClass" : "org.openmrs.Encounter",
-      "enabled" : false
+      "classTitle" : "Location",
+      "category" : "location",
+      "openMrsClass" : "org.openmrs.Location",
+      "enabled" : true,
+      "preferredClient" : "fhir"
     }, {
-      "classTitle" : "Visit",
-      "category" : "visit",
-      "openMrsClass" : "org.openmrs.Visit",
-      "enabled" : false
+      "classTitle" : "Observation",
+      "category" : "observation",
+      "openMrsClass" : "org.openmrs.Obs",
+      "enabled" : true,
+      "preferredClient" : null
     } ]
   },
   "whitelist" : {

--- a/api/src/test/resources/sampleSyncConfiguration2.json
+++ b/api/src/test/resources/sampleSyncConfiguration2.json
@@ -5,7 +5,13 @@
     "localInstanceId" : "localInstanceId",
     "persistSuccessAudit" : false,
     "persistFailureAudit" : false,
-    "clients" : {"rest" : {"hostAddress" : "http://address.org"}}
+    "clients" : {
+      "rest" : {
+        "hostAddress" : "http://address.org",
+        "login" : "clientLogin",
+        "password" : "clientPassword"
+      }
+    }
   },
   "push" : {
     "enabled" : true,

--- a/api/src/test/resources/sampleSyncConfiguration2.json
+++ b/api/src/test/resources/sampleSyncConfiguration2.json
@@ -4,7 +4,8 @@
     "localFeedLocation" : "defaultAddress",
     "localInstanceId" : "localInstanceId",
     "persistSuccessAudit" : false,
-    "persistFailureAudit" : false
+    "persistFailureAudit" : false,
+    "clients" : {"rest" : {"hostAddress" : "http://address.org"}}
   },
   "push" : {
     "enabled" : true,

--- a/omod/src/main/java/org/openmrs/module/sync2/page/controller/Sync2PageController.java
+++ b/omod/src/main/java/org/openmrs/module/sync2/page/controller/Sync2PageController.java
@@ -37,6 +37,6 @@ public class Sync2PageController {
 	}
 
 	private boolean parentInstanceUriIsEmpty() {
-		return StringUtils.isBlank(SyncUtils.getParentBaseUrl());
+		return StringUtils.isBlank(SyncUtils.getParentBaseUrl(null));
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/sync2/web/controller/rest/SyncAuditRestController.java
+++ b/omod/src/main/java/org/openmrs/module/sync2/web/controller/rest/SyncAuditRestController.java
@@ -8,7 +8,7 @@ import org.openmrs.module.sync2.api.service.SyncAuditService;
 import org.openmrs.module.sync2.api.exceptions.SyncException;
 import org.openmrs.module.sync2.api.model.audit.AuditMessage;
 import org.openmrs.module.sync2.api.model.enums.InstanceId;
-import org.openmrs.module.sync2.api.model.enums.Operation;
+import org.openmrs.module.sync2.api.model.enums.SyncOperation;
 import org.openmrs.module.sync2.api.model.enums.Resources;
 import org.openmrs.module.sync2.api.model.enums.Status;
 import org.openmrs.module.sync2.api.converter.StringToAuditMessageConverter;
@@ -172,8 +172,8 @@ public class SyncAuditRestController {
 
     private String extractOperation(String enumValue) {
         try {
-            return Operation.valueOf(enumValue).name().equals(Operation.ALL.name()) ?
-                    "" : Operation.valueOf(enumValue).name();
+            SyncOperation operation = SyncOperation.getByValue(enumValue);
+            return operation.equals(SyncOperation.ALL) ? "" : operation.name();
         } catch (IllegalArgumentException e) {
             throw new SyncException(String.format("There is no suitable operation: %s.", enumValue), e);
         }


### PR DESCRIPTION
* Added the "preferredClient" field to the ClassConfig and added the Serializable interface to the config classes
* Changed the approach to determine the preferred client (first try to use the class preferred client) and updated the unit tests
* Added support of specific clients configuration